### PR TITLE
Unbreak build on x86 without MMX

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,3 +1,5 @@
+include(CheckCXXCompilerFlag)
+
 set(SRCS
 	src/AAFilter.cpp
 	src/BPMDetect.cpp
@@ -13,6 +15,19 @@ set(SRCS
 	src/SoundTouch.cpp
 	src/sse_optimized.cpp
 	src/TDStretch.cpp)
+
+if(NOT MSVC)
+	check_cxx_compiler_flag(-mmmx SOUNDTOUCH_HAS_MMMX)
+	check_cxx_compiler_flag(-msse SOUNDTOUCH_HAS_MSSE)
+	if(SOUNDTOUCH_HAS_MMMX)
+		set_source_files_properties(src/mmx_optimized.cpp
+					    PROPERTIES COMPILE_FLAGS "-mmmx")
+	endif()
+	if(SOUNDTOUCH_HAS_MSSE)
+		set_source_files_properties(src/sse_optimized.cpp
+					    PROPERTIES COMPILE_FLAGS "-msse")
+	endif()
+endif()
 
 add_library(SoundTouch STATIC ${SRCS})
 target_include_directories(SoundTouch PUBLIC include PRIVATE src)


### PR DESCRIPTION
FreeBSD i386 defaults to -march=i486 which doesn't enable MMX or SSE by default. Upstream is [not affected](https://gitlab.com/soundtouch/soundtouch/blob/soundtouch-2.0.0/source/SoundTouch/Makefile.am#L39-60).
```
/usr/bin/c++   -Iinclude -Isrc  -MD -MT CMakeFiles/SoundTouch.dir/src/mmx_optimized.o -MF CMakeFiles/SoundTouch.dir/src/mmx_optimized.o.d -o CMakeFiles/SoundTouch.dir/src/mmx_optimized.o -c src/mmx_optimized.cpp
src/mmx_optimized.cpp:82:15: error: always_inline function '_mm_cvtsi32_si64' requires target feature 'mmx', but would be inlined into function 'calcCrossCorr' that is compiled without support for 'mmx'
    shifter = _m_from_int(overlapDividerBitsNorm);
              ^
/usr/bin/../lib/clang/4.0.0/include/mmintrin.h:1491:21: note: expanded from macro '_m_from_int'
#define _m_from_int _mm_cvtsi32_si64
                    ^
src/mmx_optimized.cpp:83:23: error: always_inline function '_mm_setzero_si64' requires target feature 'mmx', but would be inlined into function 'calcCrossCorr' that is compiled without support for 'mmx'
    normaccu = accu = _mm_setzero_si64();
                      ^
src/mmx_optimized.cpp:96:16: error: always_inline function '_mm_add_pi32' requires target feature 'mmx', but would be inlined into function 'calcCrossCorr' that is compiled without support for 'mmx'
        temp = _mm_add_pi32(_mm_sra_pi32(_mm_madd_pi16(pVec1[0], pVec2[0]), shifter),
               ^
src/mmx_optimized.cpp:96:29: error: always_inline function '_mm_sra_pi32' requires target feature 'mmx', but would be inlined into function 'calcCrossCorr' that is compiled without support for 'mmx'
        temp = _mm_add_pi32(_mm_sra_pi32(_mm_madd_pi16(pVec1[0], pVec2[0]), shifter),
                            ^
src/mmx_optimized.cpp:96:42: error: always_inline function '_mm_madd_pi16' requires target feature 'mmx', but would be inlined into function 'calcCrossCorr' that is compiled without support for 'mmx'
        temp = _mm_add_pi32(_mm_sra_pi32(_mm_madd_pi16(pVec1[0], pVec2[0]), shifter),
                                         ^
src/mmx_optimized.cpp:97:29: error: always_inline function '_mm_sra_pi32' requires target feature 'mmx', but would be inlined into function 'calcCrossCorr' that is compiled without support for 'mmx'
                            _mm_sra_pi32(_mm_madd_pi16(pVec1[1], pVec2[1]), shifter));
                            ^
src/mmx_optimized.cpp:97:42: error: always_inline function '_mm_madd_pi16' requires target feature 'mmx', but would be inlined into function 'calcCrossCorr' that is compiled without support for 'mmx'
                            _mm_sra_pi32(_mm_madd_pi16(pVec1[1], pVec2[1]), shifter));
                                         ^
src/mmx_optimized.cpp:98:17: error: always_inline function '_mm_add_pi32' requires target feature 'mmx', but would be inlined into function 'calcCrossCorr' that is compiled without support for 'mmx'
        temp2 = _mm_add_pi32(_mm_sra_pi32(_mm_madd_pi16(pVec1[0], pVec1[0]), shifter),
                ^
src/mmx_optimized.cpp:98:30: error: always_inline function '_mm_sra_pi32' requires target feature 'mmx', but would be inlined into function 'calcCrossCorr' that is compiled without support for 'mmx'
        temp2 = _mm_add_pi32(_mm_sra_pi32(_mm_madd_pi16(pVec1[0], pVec1[0]), shifter),
                             ^
src/mmx_optimized.cpp:98:43: error: always_inline function '_mm_madd_pi16' requires target feature 'mmx', but would be inlined into function 'calcCrossCorr' that is compiled without support for 'mmx'
        temp2 = _mm_add_pi32(_mm_sra_pi32(_mm_madd_pi16(pVec1[0], pVec1[0]), shifter),
                                          ^
src/mmx_optimized.cpp:99:29: error: always_inline function '_mm_sra_pi32' requires target feature 'mmx', but would be inlined into function 'calcCrossCorr' that is compiled without support for 'mmx'
                            _mm_sra_pi32(_mm_madd_pi16(pVec1[1], pVec1[1]), shifter));
                            ^
src/mmx_optimized.cpp:99:42: error: always_inline function '_mm_madd_pi16' requires target feature 'mmx', but would be inlined into function 'calcCrossCorr' that is compiled without support for 'mmx'
                            _mm_sra_pi32(_mm_madd_pi16(pVec1[1], pVec1[1]), shifter));
                                         ^
src/mmx_optimized.cpp:100:16: error: always_inline function '_mm_add_pi32' requires target feature 'mmx', but would be inlined into function 'calcCrossCorr' that is compiled without support for 'mmx'
        accu = _mm_add_pi32(accu, temp);
               ^
src/mmx_optimized.cpp:101:20: error: always_inline function '_mm_add_pi32' requires target feature 'mmx', but would be inlined into function 'calcCrossCorr' that is compiled without support for 'mmx'
        normaccu = _mm_add_pi32(normaccu, temp2);
                   ^
src/mmx_optimized.cpp:103:16: error: always_inline function '_mm_add_pi32' requires target feature 'mmx', but would be inlined into function 'calcCrossCorr' that is compiled without support for 'mmx'
        temp = _mm_add_pi32(_mm_sra_pi32(_mm_madd_pi16(pVec1[2], pVec2[2]), shifter),
               ^
src/mmx_optimized.cpp:103:29: error: always_inline function '_mm_sra_pi32' requires target feature 'mmx', but would be inlined into function 'calcCrossCorr' that is compiled without support for 'mmx'
        temp = _mm_add_pi32(_mm_sra_pi32(_mm_madd_pi16(pVec1[2], pVec2[2]), shifter),
                            ^
src/mmx_optimized.cpp:103:42: error: always_inline function '_mm_madd_pi16' requires target feature 'mmx', but would be inlined into function 'calcCrossCorr' that is compiled without support for 'mmx'
        temp = _mm_add_pi32(_mm_sra_pi32(_mm_madd_pi16(pVec1[2], pVec2[2]), shifter),
                                         ^
src/mmx_optimized.cpp:104:29: error: always_inline function '_mm_sra_pi32' requires target feature 'mmx', but would be inlined into function 'calcCrossCorr' that is compiled without support for 'mmx'
                            _mm_sra_pi32(_mm_madd_pi16(pVec1[3], pVec2[3]), shifter));
                            ^
src/mmx_optimized.cpp:104:42: error: always_inline function '_mm_madd_pi16' requires target feature 'mmx', but would be inlined into function 'calcCrossCorr' that is compiled without support for 'mmx'
                            _mm_sra_pi32(_mm_madd_pi16(pVec1[3], pVec2[3]), shifter));
                                         ^
fatal error: too many errors emitted, stopping now [-ferror-limit=]
20 errors generated.
```
